### PR TITLE
STOP prints over MessageAPI

### DIFF
--- a/features.json
+++ b/features.json
@@ -871,7 +871,6 @@
       "production"
    ],
    "posPrintsOverMessageApi": [
-      "pos>=4.390",
       "57dab243332f920e00b6cc17"
    ],
    "paymentSessionsOverMessageApi": [


### PR DESCRIPTION
prints over messageapi can get stuck and the rest of the queue does not get processed (Hotel Šustr)